### PR TITLE
Hotfix for hairremoval attributes violated exclusively bug

### DIFF
--- a/source/models/entry.ts
+++ b/source/models/entry.ts
@@ -170,7 +170,7 @@ export const hairRemovalMeta = {
 
     attributes: {
         type: "array",
-        exclusively: ["insurancePay", "transfrendly", "hasDoctor"]
+        exclusively: ["insurancePay", "transfriendly", "hasDoctor"]
     },
 
     offers: {

--- a/source/models/entry.ts
+++ b/source/models/entry.ts
@@ -73,17 +73,19 @@ export const address = {
     },
 
     plz: {
-        presence: { allowEmpty: false },
+        presence: false,
         type: "string"
     },
 
     street: {
-        presence: { allowEmpty: false },
+        presence: false,
+        requires: "city",
         type: "string"
     },
 
     house: {
-        presence: { allowEmpty: false },
+        presence: false,
+        requires: "street",
         type: "string",
         length: {
             minimum: 1,


### PR DESCRIPTION
There was a typo of "transfriendly" in the validation models that caused a 422 validation error. This is now fixed.